### PR TITLE
Memory-efficient TCA

### DIFF
--- a/scSpace/models.py
+++ b/scSpace/models.py
@@ -47,21 +47,58 @@ class TCA:
         :return: Xs_new and Xt_new after TCA
         '''
         X = np.hstack((Xs.T, Xt.T))
-        X /= np.linalg.norm(X, axis=0)
+        # Safe column norm — cells with zero expression across all genes
+        # must not produce NaN (a pre-existing bug exposed by full data).
+        norms = np.linalg.norm(X, axis=0)
+        X[:, norms > 0] /= norms[norms > 0]
         m, n = X.shape
         ns, nt = len(Xs), len(Xt)
-        e = np.vstack((1 / ns * np.ones((ns, 1)), -1 / nt * np.ones((nt, 1))))
-        M = e * e.T
-        M = M / np.linalg.norm(M, 'fro')
-        H = np.eye(n) - 1 / n * np.ones((n, n))
-        K = kernel(self.kernel_type, X, None, gamma=self.gamma)
-        n_eye = m if self.kernel_type == 'primal' else n
-        a, b = K @ M @ K.T + self.lamb * np.eye(n_eye), K @ H @ K.T
+
+        if self.kernel_type == 'primal':
+            # ── Memory-efficient TCA ──────────────────────────────────
+            # Original formulation constructs two (n×n) matrices M and H,
+            # which cost O(n²) memory (~25 GB for 56K samples).
+            #
+            # M = e·eᵀ / ‖e·eᵀ‖_F  (rank-1, where e = [1/ns; -1/nt])
+            # H = I - (1/n)·1·1ᵀ    (centering matrix)
+            #
+            # For primal kernel K = X  →  a, b are (m, m) = (541, 541):
+            #
+            #   K·M·Kᵀ = (X·e)·(X·e)ᵀ / (1/ns+1/nt)    [vector outer product]
+            #   K·H·Kᵀ = X·Xᵀ - (1/n)·(X·1)·(X·1)ᵀ     [gram − rank-1 update]
+            #
+            # Memory: O(m·n + m²) ≈ 244 MB instead of O(n²) ≈ 50 GB.
+            # ──────────────────────────────────────────────────────────
+
+            # X·e  — difference of column means (m, 1)
+            Xe = X[:, :ns].sum(axis=1, keepdims=True) / ns \
+               - X[:, ns:].sum(axis=1, keepdims=True) / nt
+            norm_factor = 1 / ns + 1 / nt            # ‖e·eᵀ‖_F
+            a = (Xe @ Xe.T) / norm_factor + self.lamb * np.eye(m)
+
+            # X·Xᵀ and X·1  for centering (m, m) and (m, 1)
+            XXt = X @ X.T
+            X1 = X.sum(axis=1, keepdims=True)
+            b = XXt - (X1 @ X1.T) / n
+
+            K = X  # primal: kernel is identity
+        else:
+            # Fallback — for linear / rbf kernels K is (n × n) so the
+            # (n × n) M and H matrices are unavoidable here.
+            K = kernel(self.kernel_type, X, None, gamma=self.gamma)
+            e = np.vstack((1 / ns * np.ones((ns, 1)), -1 / nt * np.ones((nt, 1))))
+            M = (e * e.T) / (1 / ns + 1 / nt)
+            H = np.eye(n) - np.ones((n, n)) / n
+            n_eye = n
+            a = K @ M @ K.T + self.lamb * np.eye(n_eye)
+            b = K @ H @ K.T
+
         w, V = scipy.linalg.eig(a, b)
         ind = np.argsort(w)
         A = V[:, ind[:self.dim]]
         Z = A.T @ K
-        Z /= np.linalg.norm(Z, axis=0)
+        norms_z = np.linalg.norm(Z, axis=0)
+        Z[:, norms_z > 0] /= norms_z[norms_z > 0]
 
         Xs_new, Xt_new = Z[:, :ns].T, Z[:, ns:].T
         return Xs_new, Xt_new


### PR DESCRIPTION
This PR improves the memory efficiency of TCA on large datasets and fixes a normalization edge case that could produce NaN values. The changes are focused on the TCA fit implementation.

# Background
In the original implementation, the primal mode explicitly constructs n×n M and H matrices. With large sample sizes (for example, around 56k samples), this leads to very high memory usage and can cause OOM failures.
Also, column normalization did not handle zero-norm columns, which could result in NaN values.

# What Changed

Reworked the primal-kernel computation path to avoid explicitly building n×n M/H matrices.
Replaced matrix products with low-rank equivalent forms:
K·M·Kᵀ is computed via an outer product based on Xe.
K·H·Kᵀ is computed as XXᵀ minus a rank-1 centering update.
Added safe normalization for both input X and projected Z, normalizing only columns with norm > 0.
Kept the non-primal branches (linear/rbf) as fallback with the original logic.
# Expected Impact

Significantly lower memory usage in primal mode, from O(n²) to approximately O(m·n + m²).
Better scalability and reduced OOM risk on large datasets.
Improved numerical stability by preventing NaN generation from zero columns.
# Compatibility

No public API changes.
Primal branch internal computation path changed but remains mathematically equivalent.
Linear/RBF branches preserve existing behavior.
# Validation Notes

The commit modifies only the TCA implementation file.
Full end-to-end regression/training was not run in this step; it is recommended to run a full pipeline check on representative datasets.